### PR TITLE
config port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Force-Port-Mod
-A fabric mod which forces the port of the "open to lan" feature to be 25565.
+A fabric mod which forces the port of the "open to lan" feature to a preset number, by default 25565.
 
 Releases Page: https://github.com/DuncanRuns/Force-Port-Mod/releases

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,12 @@ dependencies {
 	modImplementation "com.github.contariaa:speedrunapi:v2.1-1.16.1"
 }
 
+loom {
+	mixin {
+		useLegacyMixinAp = false
+	}
+}
+
 processResources {
 	inputs.property "version", project.version
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,16 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
+repositories {
+	maven {url "https://jitpack.io" }
+}
+
 dependencies {
 	//to change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	modImplementation "com.github.contariaa:speedrunapi:v2.1-1.16.1"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,6 @@ yarn_mappings       = 1.16.1+build.21
 loader_version      = 0.15.7
 
 #Mod properties
-mod_version         = 1.2.0
+mod_version         = 1.3.0
 maven_group         = me.duncanruns.forceport
 archives_base_name  = forceport

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,10 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
+        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/src/main/java/me/duncanruns/forceport/ForcePort.java
+++ b/src/main/java/me/duncanruns/forceport/ForcePort.java
@@ -1,0 +1,25 @@
+package me.duncanruns.forceport;
+
+import net.fabricmc.api.ModInitializer;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ForcePort implements ModInitializer {
+
+    public static Logger LOGGER = LogManager.getLogger();
+
+    public static final String MOD_ID = "forceport";
+    public static final String MOD_NAME = "Force Port Mod";
+
+    @Override
+    public void onInitialize() {
+        log(Level.INFO, "Initializing");
+    }
+
+    public static void log(Level level, String message){
+        LOGGER.log(level, "["+MOD_NAME+"] " + message);
+    }
+
+}

--- a/src/main/java/me/duncanruns/forceport/ForcePort.java
+++ b/src/main/java/me/duncanruns/forceport/ForcePort.java
@@ -1,25 +1,37 @@
 package me.duncanruns.forceport;
 
 import net.fabricmc.api.ModInitializer;
-
-import org.apache.logging.log4j.Level;
+import net.fabricmc.loader.api.FabricLoader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 public class ForcePort implements ModInitializer {
+    public static final Logger LOGGER = LogManager.getLogger(ForcePort.class);
 
-    public static Logger LOGGER = LogManager.getLogger();
-
-    public static final String MOD_ID = "forceport";
-    public static final String MOD_NAME = "Force Port Mod";
+    public static ForcePortConfig config;
+    public static int port = 25565;
+    public static Path configFile = FabricLoader.getInstance().getConfigDir().resolve("forceport.txt");
+    public static final boolean speedrunapi = FabricLoader.getInstance().isModLoaded("speedrunapi");
 
     @Override
     public void onInitialize() {
-        log(Level.INFO, "Initializing");
+        if (speedrunapi) return;
+        try {
+            if (Files.notExists(configFile)) {
+                Files.createFile(configFile);
+                Files.write(configFile, Integer.toString(port).getBytes(StandardCharsets.UTF_8));
+            } else if (Files.exists(configFile)) {
+                port = Math.max(1024, Math.min(65565, Integer.parseInt(new String(Files.readAllBytes(configFile), StandardCharsets.UTF_8))));
+            } else {
+                LOGGER.error("config file is in superposition");
+            }
+        } catch (IOException | NumberFormatException e) {
+            LOGGER.error("could not read or create config");
+        }
     }
-
-    public static void log(Level level, String message){
-        LOGGER.log(level, "["+MOD_NAME+"] " + message);
-    }
-
 }

--- a/src/main/java/me/duncanruns/forceport/ForcePortConfig.java
+++ b/src/main/java/me/duncanruns/forceport/ForcePortConfig.java
@@ -1,0 +1,20 @@
+package me.duncanruns.forceport;
+
+import me.contaria.speedrunapi.config.api.SpeedrunConfig;
+import me.contaria.speedrunapi.config.api.annotations.Config;
+
+public class ForcePortConfig implements SpeedrunConfig {
+    @Config.Numbers.Whole.Bounds(min = 1024, max = 65565)
+    @Config.Numbers.TextField
+    public int port = 25565;
+
+    @Override
+    public void finishLoading() {
+        ForcePort.config = this;
+    }
+
+    @Override
+    public String modID() {
+        return "forceport";
+    }
+}

--- a/src/main/java/me/duncanruns/forceport/mixin/NetworkUtilsMixin.java
+++ b/src/main/java/me/duncanruns/forceport/mixin/NetworkUtilsMixin.java
@@ -1,5 +1,6 @@
 package me.duncanruns.forceport.mixin;
 
+import me.duncanruns.forceport.*;
 import net.minecraft.client.util.NetworkUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -12,6 +13,6 @@ public abstract class NetworkUtilsMixin {
      */
     @Overwrite
     public static int findLocalPort() {
-        return 25565;
+        return ForcePort.speedrunapi ? ForcePort.config.port : ForcePort.port;
     }
 }

--- a/src/main/java/me/duncanruns/forceport/mixin/NetworkUtilsMixin.java
+++ b/src/main/java/me/duncanruns/forceport/mixin/NetworkUtilsMixin.java
@@ -1,6 +1,6 @@
 package me.duncanruns.forceport.mixin;
 
-import me.duncanruns.forceport.*;
+import me.duncanruns.forceport.ForcePort;
 import net.minecraft.client.util.NetworkUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;

--- a/src/main/java/me/duncanruns/forceport/mixin/PlayerManagerMixin.java
+++ b/src/main/java/me/duncanruns/forceport/mixin/PlayerManagerMixin.java
@@ -11,7 +11,7 @@ public abstract class PlayerManagerMixin {
      * @author AppDevMichael
      * @reason Replace the default 8 player limit with maximum integer value
      */
-    @ModifyVariable(method = "/<init>/", at = @At(value = "HEAD"), argsOnly = true)
+    @ModifyVariable(method = "<init>*", at = @At(value = "HEAD"), argsOnly = true)
     private static int changeMaxPlayers(int maxPlayers) {
         if (maxPlayers == 8) return Integer.MAX_VALUE;
         return maxPlayers;

--- a/src/main/java/me/duncanruns/forceport/mixin/PlayerManagerMixin.java
+++ b/src/main/java/me/duncanruns/forceport/mixin/PlayerManagerMixin.java
@@ -11,7 +11,7 @@ public abstract class PlayerManagerMixin {
      * @author AppDevMichael
      * @reason Replace the default 8 player limit with maximum integer value
      */
-    @ModifyVariable(method = "<init>", at = @At(value = "HEAD"), argsOnly = true)
+    @ModifyVariable(method = "/<init>/", at = @At(value = "HEAD"), argsOnly = true)
     private static int changeMaxPlayers(int maxPlayers) {
         if (maxPlayers == 8) return Integer.MAX_VALUE;
         return maxPlayers;

--- a/src/main/resources/assets/forceport/lang/en_us.json
+++ b/src/main/resources/assets/forceport/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "speedrunapi.config.forceport.option.port": "Port"
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "forceport",
   "version": "${version}",
   "name": "Force Port Mod",
-  "description": "Forces the port of open to lan to be 25565 and increases the player limit of open to lan to as large as it can be.",
+  "description": "Forces the port of open to lan to a set number and increases the player limit of open to lan to as large as it can be.",
   "authors": [
     {
       "name": "DuncanRuns",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,6 +14,13 @@
   "license": "MIT",
   "icon": "assets/forceport/icon.png",
   "environment": "*",
+  "entrypoints": {
+    "main": [
+      "me.duncanruns.forceport.ForcePort"
+    ],
+    "client": [],
+    "server": []
+  },
   "mixins": [
     "forceport.mixins.json"
   ],

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,26 +5,41 @@
   "name": "Force Port Mod",
   "description": "Forces the port of open to lan to be 25565 and increases the player limit of open to lan to as large as it can be.",
   "authors": [
-    "DuncanRuns",
+    {
+      "name": "DuncanRuns",
+      "contact": {
+        "homepage": "https://github.com/DuncanRuns"
+      }
+    }
+  ],
+  "contributors": [
     "AppDevMichael",
     "tildejustin"
   ],
-  "contributors": [],
-  "contact": {},
+  "contact": {
+    "sources": "https://github.com/DuncanRuns/Force-Port-Mod",
+    "issues": "https://github.com/DuncanRuns/Force-Port-Mod/issues"
+  },
   "license": "MIT",
   "icon": "assets/forceport/icon.png",
   "environment": "*",
   "entrypoints": {
     "main": [
       "me.duncanruns.forceport.ForcePort"
-    ],
-    "client": [],
-    "server": []
+    ]
   },
   "mixins": [
     "forceport.mixins.json"
   ],
   "depends": {
     "fabricloader": ">=0.12.9"
+  },
+  "breaks": {
+    "speedrunapi": "<2.0.0-"
+  },
+  "custom": {
+    "speedrunapi": {
+      "config":"me.duncanruns.forceport.ForcePortConfig"
+    }
   }
 }


### PR DESCRIPTION
closes #2 
justified by those new bots that are affecting coop runs
new loom correctly resolves the ctor signature at compile time, causing crashes in 1.16.5 and likely every other version. it incorrectly also resolves the wildcard so I switched to in-place mixin remapping